### PR TITLE
React router 1

### DIFF
--- a/examples/index.js
+++ b/examples/index.js
@@ -14,6 +14,7 @@ import GAChoropleth from './components/GAChoropleth';
 import MyCustomLayout from './layouts/MyCustomLayout';
 import GADashboard from './app';
 import GAMultiSelect from './components/GAMultiSelect';
+import Router from '../src/components/Router';
 
 console.log('DASHBOARD SETTINGS', settings);
-ReactDOM.render(<GADashboard {...settings} />, document.getElementById('root'));
+ReactDOM.render(<Router {...settings} />, document.getElementById('root'));

--- a/examples/index.js
+++ b/examples/index.js
@@ -14,7 +14,7 @@ import GAChoropleth from './components/GAChoropleth';
 import MyCustomLayout from './layouts/MyCustomLayout';
 import GADashboard from './app';
 import GAMultiSelect from './components/GAMultiSelect';
-import Router from '../src/components/Router';
+import App from '../src/components/App';
 
 console.log('DASHBOARD SETTINGS', settings);
-ReactDOM.render(<Router {...settings} />, document.getElementById('root'));
+ReactDOM.render(<App {...settings} />, document.getElementById('root'));

--- a/examples/settings.js
+++ b/examples/settings.js
@@ -124,7 +124,7 @@ export var settings = {
 							type: 'Choropleth',
 							format: 'geojson',
 							fetchData: {
-								url: './data/apollo-parsed-1737-325_0.csv',
+								url: '/data/apollo-parsed-1737-325_0.csv',
 								type: 'backend',
 								backend: 'csv',
 								// delimiter: '\t'
@@ -133,7 +133,7 @@ export var settings = {
 							dataKeyField: 'Zone',
 							dataValueField: 'Total Observers',
 							geometryKeyField: 'name',
-							geometry: './data/zones.geojson', // topojson or geojson
+							geometry: '/data/zones.geojson', // topojson or geojson
 							projection: 'equirectangular', // https://github.com/d3/d3/wiki/Geo-Projections
 							scaleDenominator: .7,
 							borderColor: '#000000',

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "lodash": "^4.6.1",
     "phantomjs": "^2.1.7",
     "react-nvd3": "git+https://github.com/NuCivic/react-nvd3.git",
+    "react-router": "^2.5.2",
     "react-select": "git+https://github.com/JedWatson/react-select.git",
     "topojson": "^1.6.24"
   },

--- a/src/ReactDashboard.js
+++ b/src/ReactDashboard.js
@@ -15,7 +15,7 @@ export {default as Multi} from './components/Multi';
 export {default as Table } from './components/Table';
 export {default as Text } from './components/Text';
 export {default as ReactSelect} from './components/ReactSelect';
-export {default as Router} from './components/Router';
+export {default as App} from './components/App';
 
 // UTILS
 export {default as Registry } from './utils/Registry';

--- a/src/ReactDashboard.js
+++ b/src/ReactDashboard.js
@@ -15,6 +15,7 @@ export {default as Multi} from './components/Multi';
 export {default as Table } from './components/Table';
 export {default as Text } from './components/Text';
 export {default as ReactSelect} from './components/ReactSelect';
+export {default as Router} from './components/Router';
 
 // UTILS
 export {default as Registry } from './utils/Registry';

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -1,9 +1,9 @@
 import React, { Component } from 'react';
 import Registry from '../utils/Registry';
 import Dashboard from './Dashboard';
-import { Router as _Router, Route, Link, browserHistory } from 'react-router'
+import { Router, Route, Link, browserHistory } from 'react-router'
 
-export default class Router extends Component {
+export default class App extends Component {
   constructor(props) {
     super(props);
   }
@@ -11,11 +11,11 @@ export default class Router extends Component {
   render() {
     let props = this.props;
     return (
-      <_Router history={browserHistory} >
+      <Router history={browserHistory} >
         <Route path="/" component={Dashboard} {...props} />
-      </_Router>   
+      </Router>   
     )
   }
 }
 
-Registry.set('Router', Router);
+Registry.set('App', App);

--- a/src/components/Dashboard.js
+++ b/src/components/Dashboard.js
@@ -21,7 +21,7 @@ export default class Dashboard extends BaseComponent {
   
   render() {
     let markup;
-    let props = Object.assign({globalData: this.state.data || []}, this.props);
+    let props = Object.assign({globalData: this.state.data || []}, this.props.route || this.props);
     if (props.layout) {
       let layout = (typeof this.props.layout === 'String') ? Registry.get(this.props.layout) : this.props.layout;
       return (

--- a/src/components/Router.js
+++ b/src/components/Router.js
@@ -1,0 +1,21 @@
+import React, { Component } from 'react';
+import Registry from '../utils/Registry';
+import Dashboard from './Dashboard';
+import { Router as _Router, Route, Link, browserHistory } from 'react-router'
+
+export default class Router extends Component {
+  constructor(props) {
+    super(props);
+  }
+  
+  render() {
+    let props = this.props;
+    return (
+      <_Router history={browserHistory} >
+        <Route path="/" component={Dashboard} {...props} />
+      </_Router>   
+    )
+  }
+}
+
+Registry.set('Router', Router);


### PR DESCRIPTION
A VERY basic implementation - this loads the dashboard at the '/' route. Settings are passed to dashboard as `this.props.route`.

This accomplishes some important goals:

• in the future was can update the route to `route/:settingsID/:entityID` to dynamically load settings files, etc
• We can pass params to the route, for instance `?countyFilter=1234&countyFilter=2345&stateFilter=1234`

I don't think, for now, that we need to add any more complexity here.